### PR TITLE
feat(NODE-6627): Add TS support to encrypted schemas

### DIFF
--- a/test/types/schema.test.ts
+++ b/test/types/schema.test.ts
@@ -24,7 +24,7 @@ import {
   ValidateOpts,
   BufferToBinary
 } from 'mongoose';
-import { Binary } from 'mongodb';
+import { Binary, BSON } from 'mongodb';
 import { IsPathRequired } from '../../types/inferschematype';
 import { expectType, expectError, expectAssignable } from 'tsd';
 import { ObtainDocumentPathType, ResolvePathType } from '../../types/inferschematype';
@@ -590,6 +590,16 @@ const batchSchema2 = new Schema({ name: String }, { discriminatorKey: 'kind', st
   return 1;
 } } });
 batchSchema2.discriminator('event', eventSchema2);
+
+
+function encryptionType() {
+  const keyId = new BSON.UUID();
+  expectError<Schema>(new Schema({ name: { type: String, encrypt: { keyId } } }, { encryptionType: 'newFakeEncryptionType' }));
+  expectError<Schema>(new Schema({ name: { type: String, encrypt: { keyId } } }, { encryptionType: 1 }));
+
+  expectType<Schema>(new Schema({ name: { type: String, encrypt: { keyId } } }, { encryptionType: 'queryableEncryption' }));
+  expectType<Schema>(new Schema({ name: { type: String, encrypt: { keyId } } }, { encryptionType: 'csfle' }));
+}
 
 function gh11828() {
   interface IUser {

--- a/test/types/schemaTypeOptions.test.ts
+++ b/test/types/schemaTypeOptions.test.ts
@@ -1,3 +1,4 @@
+import { BSON } from 'mongodb';
 import {
   AnyArray,
   Schema,
@@ -73,4 +74,40 @@ function defaultOptions() {
   expectType<Record<string, any>>(new Schema.Types.Double('none').defaultOptions);
   expectType<Record<string, any>>(new Schema.Types.Subdocument('none').defaultOptions);
   expectType<Record<string, any>>(new Schema.Types.UUID('none').defaultOptions);
+}
+
+function encrypt() {
+  const keyId = new BSON.UUID();
+
+  new SchemaTypeOptions<string>()['encrypt'] = { keyId, algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic' };
+  new SchemaTypeOptions<string>()['encrypt'] = { keyId, algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic' };
+  new SchemaTypeOptions<string>()['encrypt'] = { keyId, algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Random' };
+  new SchemaTypeOptions<string>()['encrypt'] = { keyId, algorithm: 'Indexed' };
+  new SchemaTypeOptions<string>()['encrypt'] = { keyId, algorithm: 'Unindexed' };
+  new SchemaTypeOptions<string>()['encrypt'] = { keyId, algorithm: 'Range' };
+  new SchemaTypeOptions<string>()['encrypt'] = { keyId, algorithm: undefined };
+
+  // qe + valid queries
+  new SchemaTypeOptions<string>()['encrypt'] = { keyId, queries: 'equality' };
+  new SchemaTypeOptions<string>()['encrypt'] = { keyId, queries: 'range' };
+  new SchemaTypeOptions<string>()['encrypt'] = { keyId, queries: undefined };
+
+  // empty object
+  expectError<SchemaTypeOptions<string>['encrypt']>({});
+
+  // invalid keyId
+  expectError<SchemaTypeOptions<string>['encrypt']>({ keyId: 'fakeId' });
+
+  // missing keyId
+  expectError<SchemaTypeOptions<string>['encrypt']>({ queries: 'equality' });
+  expectError<SchemaTypeOptions<string>['encrypt']>({ algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic' });
+
+  // invalid algorithm
+  expectError<SchemaTypeOptions<string>['encrypt']>({ keyId, algorithm: 'SHA_FAKE_ALG' });
+
+  // invalid queries
+  expectError<SchemaTypeOptions<string>['encrypt']>({ keyId, queries: 'fakeQueryOption' });
+
+  // invalid input option
+  expectError<SchemaTypeOptions<string>['encrypt']>({ keyId, invalidKey: 'fakeKeyOption' });
 }

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -258,6 +258,8 @@ declare module 'mongoose' {
      * @default false
      */
     overwriteModels?: boolean;
+
+    encryptionType?: 'csfle' | 'queryableEncryption';
   }
 
   interface DefaultSchemaOptions {

--- a/types/schemaoptions.d.ts
+++ b/types/schemaoptions.d.ts
@@ -259,6 +259,9 @@ declare module 'mongoose' {
      */
     overwriteModels?: boolean;
 
+    /**
+     *  Required when the schema is encrypted.
+     */
     encryptionType?: 'csfle' | 'queryableEncryption';
   }
 

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -1,3 +1,5 @@
+import * as BSON from 'bson';
+
 declare module 'mongoose' {
 
   /** The Mongoose Date [SchemaType](/docs/schematypes.html). */
@@ -207,6 +209,8 @@ declare module 'mongoose' {
     maxlength?: number | [number, string] | readonly [number, string];
 
     [other: string]: any;
+
+    encrypt?: EncryptSchemaTypeOptions;
   }
 
   interface Validator<DocType = any> {
@@ -217,6 +221,28 @@ declare module 'mongoose' {
   }
 
   type ValidatorFunction<DocType = any> = (this: DocType, value: any, validatorProperties?: Validator) => any;
+
+  export interface EncryptSchemaTypeOptions {
+    /** The id of the  dataKey to use for encryption */
+    keyId: BSON.UUID;
+
+    /**
+     * Specifies the type of queries that the field can be queried on for Queryable Encryption.
+     * Required when `SchemaOptions.encryptionType` is 'queryableEncryption'
+    */
+    queries?: 'equality' | 'range';
+
+    /**
+     * The algorithm to use for encryption.
+     * Required when `SchemaOptions.encryptionType` is 'csfle'
+     */
+    algorithm?:
+      | 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
+      | 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'
+      | 'Indexed'
+      | 'Unindexed'
+      | 'Range';
+  }
 
   class SchemaType<T = any, DocType = any> {
     /** SchemaType constructor */

--- a/types/schematypes.d.ts
+++ b/types/schematypes.d.ts
@@ -210,7 +210,22 @@ declare module 'mongoose' {
 
     [other: string]: any;
 
-    encrypt?: EncryptSchemaTypeOptions;
+    encrypt?: {
+      /** The id of the  dataKey to use for encryption */
+      keyId: BSON.UUID;
+
+      /**
+       * Specifies the type of queries that the field can be queried on for Queryable Encryption.
+       * Required when `SchemaOptions.encryptionType` is 'queryableEncryption'
+      */
+      queries?: 'equality' | 'range';
+
+      /**
+       * The algorithm to use for encryption.
+       * Required when `SchemaOptions.encryptionType` is 'csfle'
+       */
+      algorithm?: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic' | 'AEAD_AES_256_CBC_HMAC_SHA_512-Random' | 'Indexed' | 'Unindexed' | 'Range';
+    };
   }
 
   interface Validator<DocType = any> {
@@ -221,28 +236,6 @@ declare module 'mongoose' {
   }
 
   type ValidatorFunction<DocType = any> = (this: DocType, value: any, validatorProperties?: Validator) => any;
-
-  export interface EncryptSchemaTypeOptions {
-    /** The id of the  dataKey to use for encryption */
-    keyId: BSON.UUID;
-
-    /**
-     * Specifies the type of queries that the field can be queried on for Queryable Encryption.
-     * Required when `SchemaOptions.encryptionType` is 'queryableEncryption'
-    */
-    queries?: 'equality' | 'range';
-
-    /**
-     * The algorithm to use for encryption.
-     * Required when `SchemaOptions.encryptionType` is 'csfle'
-     */
-    algorithm?:
-      | 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
-      | 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'
-      | 'Indexed'
-      | 'Unindexed'
-      | 'Range';
-  }
 
   class SchemaType<T = any, DocType = any> {
     /** SchemaType constructor */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory.

If you're making a change to documentation, do **not** modify a `.html` file directly. Instead, find the corresponding `.pug` file or test case in the `test/docs` directory. -->

**Summary**
- Typescript now throws an error when invalid values are provided to `SchemaOptions.encryptionType` or `SchemaTypeOptions.encrypt`

<!-- Explain the **motivation** for making this change. What problem does the pull request solve? -->

**Examples**

<!-- If this code fixes a bug or adds a new feature, provide an example demonstrating the change, unless you added a test. -->

```
new Schema(name: { type: String, encrypt: { keyId: 'i am not a UUID' }, encryptionType: 'csfle'); // TS error
new Schema(name: { type: String, encrypt: { keyId: new BSON.UUID }, encryptionType: 'invalidType ); // TS error
```